### PR TITLE
[Rarbg] Without user agent the server refuse the request

### DIFF
--- a/lib/providers/rarbg.js
+++ b/lib/providers/rarbg.js
@@ -33,7 +33,7 @@ class Rarbg extends TorrentProvider {
         if (url === null) {
           return;
         }
-        return request(url);
+        return request({url: url, headers: {'User-Agent': 'curl/7.37.0'}});
       })
       .then(response => {
         let results = JSON.parse(response.body).torrent_results;
@@ -58,7 +58,7 @@ class Rarbg extends TorrentProvider {
 
   _ensureLogin() {
     if (!this.lastLoginTime || (Date.now() - this.lastLoginTime) > 840000) {
-      return request(this.scrapeDatas.baseUrl + this.scrapeDatas.getTokenUrl)
+       return request({url: this.scrapeDatas.baseUrl + this.scrapeDatas.getTokenUrl, headers: {'User-Agent': 'curl/7.37.0'}})
         .then(r => {
           this.lastLoginTime = Date.now();
           let searchUrl = this.scrapeDatas.searchUrl;


### PR DESCRIPTION
TorrentApi server needs an user agent for all request done on their server, else they return a 403 Forbidden.