### PR TITLE
Fix Ygg baseUrl and add a check for redirection

### DIFF
--- a/lib/providers/yggtorrent.js
+++ b/lib/providers/yggtorrent.js
@@ -4,7 +4,7 @@ class Yggtorrent extends TorrentProvider {
   _getScrapeDatas() {
     return {
       name: 'Yggtorrent',
-      baseUrl: 'https://yggtorrent.is',
+      baseUrl: 'https://ww1.yggtorrent.is',
       requireAuthentification: true,
       supportCookiesAuthentification: true,
       supportCredentialsAuthentification: true,

--- a/lib/torrent-provider.js
+++ b/lib/torrent-provider.js
@@ -33,11 +33,11 @@ module.exports = class TorrentProvider {
       itemSelectors: [],
       paginateSelector: '',
       torrentDetailsSelector: '',
-      enableCloudFareBypass: false
+      enableCloudFareBypass: false,
+      baseUrlChecked: false,
     };
 
     Object.assign(this.scrapeDatas, this._getScrapeDatas());
-    this._ensureNoRedirect().catch(e => console.error('Error while trying to deduct new base url', e));
   }
 
   enableProvider() {
@@ -114,7 +114,8 @@ module.exports = class TorrentProvider {
     }
 
     return this._ensureLogin()
-      .then(() => this._search(url, pageLimit))
+      .then(() => this._ensureNoRedirect())
+      .then(() => this._search(this._getUrl(category, query), pageLimit)) // recompute the url in case the base changed
       .then(result => this._postProcess(result));
   }
 
@@ -193,10 +194,14 @@ module.exports = class TorrentProvider {
   }
 
   _ensureNoRedirect() {
+    if (this.scrapeDatas.baseUrlChecked) {
+      return Promise.resolve();
+    }
     return this._request(this.scrapeDatas.baseUrl, {followRedirect: false}, null, false, false)
       .then(response => {
         if (response.statusCode >= 300 && response.statusCode < 400) {
           this.scrapeDatas.baseUrl = new URL(response.headers.location).origin;
+          this.scrapeDatas.baseUrlChecked = true;
         }
       });
   }

--- a/lib/torrent-provider.js
+++ b/lib/torrent-provider.js
@@ -4,6 +4,7 @@ const cloudscraperRequest = Promise.promisify(require('cloudscraper').request);
 const fs = require('fs');
 const format = require('string-format');
 const _ = require('lodash');
+const URL = require('url').URL;
 
 const Xray = require('x-ray-scraper/Xray');
 const makeDriver = require('request-x-ray');
@@ -190,6 +191,15 @@ module.exports = class TorrentProvider {
     }
   }
 
+  _ensureNoRedirect() {
+    return this._request(this.scrapeDatas.baseUrl, {followRedirect: false}, null, false, false)
+      .then(response => {
+        if (response.statusCode >= 300 && response.statusCode < 400) {
+          this.scrapeDatas.baseUrl = new URL(response.headers.location).origin;
+        }
+      });
+  }
+
   _login(cookie) {
     return this._request(
       this.scrapeDatas.baseUrl + this.scrapeDatas.loginUrl,
@@ -199,10 +209,13 @@ module.exports = class TorrentProvider {
     );
   }
 
-  _request(url, options = {}, body = null, ensureLogin = true) {
-    let ensureLoginPromise = ensureLogin
-      ? this._ensureLogin()
+  _request(url, options = {}, body = null, ensureLogin = true, ensureNoRedirect = true) {
+    let ensureNoRedirectPromise = ensureNoRedirect
+      ? this._ensureNoRedirect()
       : Promise.resolve();
+    let ensureLoginFn = ensureLogin
+      ? this._ensureLogin
+      : Promise.resolve;
     let req = this.scrapeDatas.enableCloudFareBypass
       ? cloudscraperRequest
       : request;
@@ -218,7 +231,7 @@ module.exports = class TorrentProvider {
       options
     );
 
-    return ensureLoginPromise.then(() => req(opts));
+    return ensureNoRedirectPromise.then(() => ensureLoginFn.call(this)).then(() => req(opts));
   }
 
   _getMagnet(torrent) {

--- a/lib/torrent-provider.js
+++ b/lib/torrent-provider.js
@@ -37,6 +37,7 @@ module.exports = class TorrentProvider {
     };
 
     Object.assign(this.scrapeDatas, this._getScrapeDatas());
+    this._ensureNoRedirect().catch(e => console.error('Error while trying to deduct new base url', e));
   }
 
   enableProvider() {


### PR DESCRIPTION
Before performing a request, ensure that it will not end up in a redirection. If that's the case, the `baseUrl` of the provider is replaced with the origin of the redirection.

Ygg base url has been replaced too.

Closes #37 