### PR TITLE
Allow overriding the configuration of a provider

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,10 @@ class TorrentSearchApi {
     );
   }
 
+  overrideConfig(providerName, newConfig) {
+    return this._getProvider(providerName).overrideConfig(newConfig);
+  }
+
   getMagnet(torrent) {
     return this._getProvider(torrent.provider).getMagnet(torrent);
   }

--- a/lib/torrent-provider.js
+++ b/lib/torrent-provider.js
@@ -103,6 +103,13 @@ module.exports = class TorrentProvider {
     };
   }
 
+  overrideConfig(newConfig) {
+    this.scrapeDatas = {
+      ...this.scrapeDatas,
+      newConfig,
+    };
+  }
+
   search(query, category, limit) {
     let pageLimit = this._getPageToFetchCount(limit);
     let url = this._getUrl(category, query);


### PR DESCRIPTION
Add a public method to allow overriding the default configuration of a provider.

Enabling this would enable that the users of the package are not stuck while a PR for changing the configuration is put together.