### PR TITLE
Get top torrents by category

### DIFF
--- a/lib/ProviderManager.js
+++ b/lib/ProviderManager.js
@@ -122,6 +122,32 @@ class ProviderManager {
       .then(results => (limit ? results.slice(0, limit) : results));
   }
 
+  top(...args) {
+    const [
+      selectedProviders,
+      query,
+      category,
+      limit
+    ] = this.handleSearchArguments(...args);
+
+    const searchPromises = selectedProviders
+      .map(p => p.search_top(category, limit))
+      .map(p => (selectedProviders.length > 1 ? silentRejection(p) : p));
+
+      return Promise.all(searchPromises)
+      .then(results =>
+        _(results)
+          .flatten()
+          .compact()
+          .orderBy(
+            [({ seeds }) => (isNaN(seeds) ? 0 : seeds), 'title'],
+            ['desc', 'desc']
+          )
+          .value()
+      )
+      .then(results => (limit ? results.slice(0, limit) : results));
+  }
+
   getTorrentDetails(torrent) {
     return this.getProvider(torrent.provider).getTorrentDetails(torrent);
   }

--- a/lib/TorrentProvider.js
+++ b/lib/TorrentProvider.js
@@ -118,6 +118,18 @@ module.exports = class TorrentProvider {
       .then(result => this.postProcess(result));
   }
 
+  search_top(category, limit) {
+    const url = this.getTopUrl(category);
+
+    if (!url) {
+      return Promise.resolve();
+    }
+
+    return this.ensureLogin()
+      .then(() => this.fetchAndParseUrl(url, limit))
+      .then(result => this.postProcess(result));
+  }
+
   getCategoryValue(categoryName) {
     if (!categoryName || categoryName === '') {
       return this.categories[this.defaultCategory];
@@ -145,6 +157,13 @@ module.exports = class TorrentProvider {
     });
 
     return url;
+  }
+
+  getTopUrl(category) {
+    if(this.hasOwnProperty('top') && this.top.hasOwnProperty(category)){
+      return `${this.baseUrl}/${this.top[category]}`;
+    }
+    return null;
   }
 
   downloadTorrent(torrent, path) {

--- a/lib/providers/1337x.js
+++ b/lib/providers/1337x.js
@@ -8,6 +8,17 @@ class _1337x extends TorrentProvider {
       name: '1337x',
       baseUrl: 'http://www.1337x.to',
       searchUrl: '/category-search/{query}/{cat}/1/',
+      top: {
+        Movies: 'top-100-movies',
+        TV: 'top-100-television',
+        Games: 'top-100-games',
+        Music: 'top-100-music',
+        Anime: 'top-100-anime',
+        Applications: 'top-100-applications',
+        Documentaries: 'top-100-documentaries',
+        Xxx: 'top-100-xxx',
+        Other: 'top-100-other',
+      },
       categories: {
         All: 'url:/search/{query}/1/',
         Movies: 'Movies',

--- a/lib/providers/thepiratebay.json
+++ b/lib/providers/thepiratebay.json
@@ -2,6 +2,15 @@
   "name": "ThePirateBay",
   "baseUrl": "https://pirateproxy.id",
   "searchUrl": "/search/{query}/0/7/{cat}",
+  "top": {
+   "Movies": "top/201",
+   "Audio": "top/100",
+   "Video": "top/200",
+   "Applications": "top/300",
+   "Games": "top/400",
+   "Porn": "top/500",
+   "Other": "top/600"
+ },
   "categories": {
      "All": "",
      "Audio": "100",

--- a/lib/providers/torrentz2.json
+++ b/lib/providers/torrentz2.json
@@ -2,6 +2,9 @@
   "name": "Torrentz2",
   "baseUrl": "https://torrentz2.eu",
   "searchUrl": "/?f={query}",
+  "top": {
+   "All": "/search?f=&safe=0"
+ },
   "categories": {
      "All": ""
   },


### PR DESCRIPTION
This pull request get top torrent by category.
For example
```
const torrents = await TorrentSearchApi.top('', 'Movies', 1);
```
I am using the same parameters as the search that's why I have an empty string on the first parameter, I suppose the could be a better way to do it, I am opened to suggestion

I implemented on the public providers when possible since I don't have any account for the private providers.