### PR TITLE
Fix downloadTorrent : Add missing path parameter to function

### DIFF
--- a/lib/providers/1337x.js
+++ b/lib/providers/1337x.js
@@ -37,11 +37,11 @@ class _1337x extends TorrentProvider {
     });
   }
 
-  downloadTorrent(torrent) {
+  downloadTorrent(torrent,path) {
     return this.xray(torrent.desc, '.infohash-box span').then(hash =>
       super.downloadTorrent({
         link: format('http://itorrents.org/torrent/{0}.torrent', hash)
-      })
+      },path)
     );
   }
 }


### PR DESCRIPTION
Path is completely ignored as it is not passed down to the download function. It currently returns a stream which is not the expected behavior as per the documention