### PR TITLE
change url for yggtorrent

### DIFF
--- a/lib/providers/yggtorrent.js
+++ b/lib/providers/yggtorrent.js
@@ -4,7 +4,7 @@ class Yggtorrent extends TorrentProvider {
   constructor() {
     super({
       name: 'Yggtorrent',
-      baseUrl: 'https://www2.yggtorrent.se',
+      baseUrl: 'https://www2.yggtorrent.si',
       requireAuthentification: true,
       supportCookiesAuthentification: true,
       supportCredentialsAuthentification: true,


### PR DESCRIPTION
The yggtorrent has changed and it breaks the authentification on the website because of the auth cookie not correctly given to the download request