### PR TITLE
Add movies category

### DIFF
--- a/lib/providers/yts.js
+++ b/lib/providers/yts.js
@@ -10,7 +10,8 @@ class Yts extends TorrentProvider {
       searchUrl:
         '/api/v2/list_movies.json?query_term={query}&sort=seeds&order=desc&set=1',
       categories: {
-        All: ''
+        All: '',
+        Movies: ''
       },
       defaultCategory: 'All',
       resultsPerPageCount: 20


### PR DESCRIPTION
If using YTS along with other providers, it can be useful to provide "Movies" as a category but this breaks the YTS implementation. This adds support for the Movies category.