### PR TITLE
Fixed a bug where torrent couldn't be searched

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "cloudscraper": "^4.6.0",
     "lodash": "^4.17.15",
+    "brotli": "^1.3.2",
     "request": "^2.88.2",
     "string-format": "^0.5.0",
     "x-ray-scraper": "^3.0.5"


### PR DESCRIPTION
# Why Changes

There was error in searching torrents before<br>

# About The Error
For more information, <a href = "https://github.com/JimmyLaurent/torrent-search-api/issues/131"> click here </a>
https://github.com/JimmyLaurent/torrent-search-api/issues/131


# Changes Made

I just added a required package in the <a href="https://github.com/JimmyLaurent/torrent-search-api/blob/94d1eba60b1b467bdfb9ca1dbdb5b106f8093003/package.json#L40"> package.json </a> file

https://github.com/JimmyLaurent/torrent-search-api/blob/94d1eba60b1b467bdfb9ca1dbdb5b106f8093003/package.json#L40
