### PR TITLE
TorrentLeech downloadTorrent should return its buffer

### DIFF
--- a/lib/providers/torrentleech.js
+++ b/lib/providers/torrentleech.js
@@ -67,7 +67,7 @@ class TorrentLeech extends TorrentProvider {
 
 	downloadTorrent(torrent, path) {
 		const url = this.baseUrl.concat('/download/', torrent.fid, '/', torrent.filename);
-		super.downloadTorrent({ link: url }, path);
+		return super.downloadTorrent({ link: url }, path);
 	}
 
 	humanFileSize(bytes, si) {


### PR DESCRIPTION
The torrent buffer is downloaded but not returned, this patches.